### PR TITLE
fix divide by zero error

### DIFF
--- a/easyratingview/src/main/java/com/aids61517/easyratingview/EasyRatingView.kt
+++ b/easyratingview/src/main/java/com/aids61517/easyratingview/EasyRatingView.kt
@@ -114,8 +114,10 @@ class EasyRatingView @JvmOverloads constructor(
 
     private var fullDrawablePaint: Paint? = null
 
-    var countOfStarsPerRow: Int = 0
-        private set
+    var countOfStarsPerRow: Int = 1
+        private set(value) {
+            field = if (value <= 0) 1 else value
+        }
 
     private val boundCalculator by lazy {
         StarBoundCalculator(this)


### PR DESCRIPTION
When remaining space less than bitmap's width, count of stars per row would be zero and crash when calculate height.